### PR TITLE
remove wasmlc snapshotter until codec registration in next version

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -119,7 +119,6 @@ import (
 	"github.com/CosmWasm/wasmd/x/wasm"
 	wasmkeeper "github.com/CosmWasm/wasmd/x/wasm/keeper"
 	wasmtypes "github.com/CosmWasm/wasmd/x/wasm/types"
-	wasmlckeeper "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v10/keeper"
 	wasmlctypes "github.com/cosmos/ibc-go/modules/light-clients/08-wasm/v10/types"
 	// unnamed import of statik for swagger UI support
 	// _ "github.com/cosmos/cosmos-sdk/client/docs/statik" // statik for swagger UI support
@@ -466,7 +465,7 @@ func NewTerpApp(
 	if manager := app.SnapshotManager(); manager != nil {
 		err = manager.RegisterExtensions(
 			wasmkeeper.NewWasmSnapshotter(app.CommitMultiStore(), app.WasmKeeper),
-			wasmlckeeper.NewWasmSnapshotter(app.CommitMultiStore(), app.IBCWasmClientKeeper),
+			// wasmlckeeper.NewWasmSnapshotter(app.CommitMultiStore(), app.IBCWasmClientKeeper),
 		)
 		if err != nil {
 			panic(fmt.Errorf("failed to register snapshot extension: %s", err))


### PR DESCRIPTION
part of solution to resolves #245, requires node operators to tune their nodes home file wasm data from being recursive and unifies into correct home path:


```sh
# Stop your node first
# pkill -f terpd
# go to terp node home directory
cd $HOME/.terpd
# Move contents from the nested wasm/wasm/ into the parent wasm/
mv wasm/wasm/* wasm/ 2>/dev/null || true
# Clean up empty nested folder
rm -rf wasm/wasm
# Verify the new structure
echo "New structure:"
tree -L 2 wasm/ || ls -l wasm/
# restart node
```

note this solution doesnt make existing snapshots compatible, only snapshots made with correct version (excluding wasmlc snapshotter)