### PR TITLE
chore(v6): default CosmWasm stack to metered bulk_memory forks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -51,7 +51,7 @@
 [submodule "crates/cosmwasm"]
 	path = crates/cosmwasm
 	url = https://github.com/permissionlessweb/cosmwasm.git
-	branch = mvp-fix
+	branch = v3.1.0-zk.0
 
 [submodule "crates/cw-asset"]
 	path = crates/cw-asset
@@ -291,7 +291,7 @@
 [submodule "crates/zk-wasmd"]
 	path = crates/zk-wasmd
 	url = https://github.com/permissionlessweb/wasmd
-	branch = mvp
+	branch = merge/upstream-wasmd-v0.70
 
 [submodule "crates/zk-wasmd.bak"]
 	path = crates/zk-wasmd.bak
@@ -301,4 +301,4 @@
 [submodule "crates/zk-wasmvm"]
 	path = crates/zk-wasmvm
 	url = https://github.com/permissionlessweb/wasmvm
-	branch = mvp
+	branch = v3.0.7-zk

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ go 1.25.9
 //
 // ZK monorepo path (DEFAULT for this branch / testnet lineage):
 //   host:    ./crates/zk-{wasmd,wasmvm}
+//   v6 default: zk-wasmd@merge/upstream-wasmd-v0.70 (bulk_memory), zk-wasmvm@v3.0.7-zk, cosmwasm@v3.1.0-zk.0 (metered memory.copy)
 //   docker:  Dockerfile (WASMVM_SOURCE=local) rewrites to /code/build/zk-deps/...
 //            after `make _docker-stage` / build-zk-local stages those trees.
 // Stock mainnet builds (WASMVM_SOURCE=github) strip these two replaces in the Dockerfile.


### PR DESCRIPTION
## Why
v6 should accept rustc ≥ 1.87 CosmWasm guests with **metered** `memory.copy` / `fill` / `init`.

## Already merged on the forks (do not revert)
- https://github.com/permissionlessweb/cosmwasm/pull/3 → `v3.1.0-zk.0`
- https://github.com/permissionlessweb/wasmvm/pull/2 → `v3.0.7-zk`
- https://github.com/permissionlessweb/wasmd/pull/1 → `merge/upstream-wasmd-v0.70`

## This PR
Updates `.gitmodules` default branches (and a go.mod comment) so v6 clones track those lines.

`app/keepers` already does `append(wasmkeeper.BuiltInCapabilities(), ...)`, so `bulk_memory` is advertised once zk-wasmd is on the merged branch.

## Not in this PR
- `feat/bulk-memory-ict` worktree path replaces (`crates/_worktrees/...`) — those stay on the isolated integration branch
- Uncommitted local Stwo / ZK dirt on groot-wan checkouts — untouched

Rebuild libwasmvm muslc against the merged cosmwasm before shipping a new alpine image.