### PR TITLE
chore(release): expedited v6 upgrade pack + Cosmovisor tsh

### DIFF
--- a/docs/workflows/upgrading.md
+++ b/docs/workflows/upgrading.md
@@ -1,24 +1,48 @@
 # Upgrade Workflow
 
 ## TLDR
-> prepare upgrade version
-> add upgradehandler
-> write unit test for upgradehandler
-> write e2e test for upgrade
-> write live daemon fork test of upgrade handler
-> prepare upgrade assets
-> release upgrade assets 
 
-> create proposal on Testnet
-> confirm upgrade works sound
-> create Mainnet proposal
+1. Prepare upgrade version + handler (`app/upgrades/<plan>`).
+2. Unit-test the handler.
+3. E2E / tsh: `make tsh-upgrade` (live fork), `make tsh-upgrade-wasm` (existing contracts), `make tsh-upgrade-cv` (Cosmovisor).
+4. Prepare artifacts: binaries, checksums, Cosmovisor `binaries.json`, upgrade guide.
+5. Expedited proposal on testnet, confirm halt + Cosmovisor swap.
+6. Expedited proposal on mainnet.
 
-## 1. UpgradeHandler Unit Tests 
-## 2. E2E tests
-## 3. Live Forks
-## 4. Prepare Upgrade Assets
-- cosmovisor json release
-- git tags, binary checksums
-- chain-registry updates
-## 5. Testnet Upgrade
-## 6. Mainnet Upgrade
+v6 plan name is **`v6`** (not the git tag). Cosmovisor folder:
+
+`~/.terpd/cosmovisor/upgrades/v6/bin/terpd`
+
+## 1. Upgrade handler unit tests
+
+See `app/upgrades/v6/upgrades_test.go`.
+
+## 2. E2E / tsh
+
+| Target | Script | What it proves |
+|--------|--------|----------------|
+| `make tsh-upgrade` | `tests/tsh/upgrade/a.sh` | Current mainnet binary loads appstate, hits `UPGRADE "v6" NEEDED`, new binary applies |
+| `make tsh-upgrade` companion | `tests/tsh/upgrade/b.sh` | Fresh genesis + **expedited** gov software-upgrade |
+| `make tsh-upgrade-wasm` | `tests/tsh/upgrade/d.sh` | Pre-v6 CosmWasm guest still executes after v6 |
+| `make tsh-upgrade-cv` | `tests/tsh/upgrade/e.sh` | **Cosmovisor** swaps genesis → `upgrades/v6` without a manual restart |
+
+## 3. Prepare upgrade assets
+
+```sh
+make create-binaries
+make release-prep RELEASE_TAG=v6.0.0
+make create-binaries-json RELEASE_TAG=v6.0.0
+make create-upgrade-guide   # or:
+python3 scripts/release/create_upgrade_guide/create_upgrade_guide.py \
+  --type coordinated -c v5.2 -u v6 -t v6.0.0 -p <id> -b <height> \
+  --out scripts/release/create_upgrade_guide/v5.2-to-v6.md
+./scripts/release/create_proposal/submit_proposal.sh --height <H> --tag v6.0.0 --name v6
+```
+
+- Cosmovisor JSON: `make create-binaries-json`
+- Checked-in guide template fill: `scripts/release/create_upgrade_guide/v5.2-to-v6.md`
+- Expedited proposal JSON: `build/upgrade-proposal-v6.json`
+
+## 4. Testnet then mainnet
+
+Create proposal on testnet first. Confirm Cosmovisor auto-restart. Then mainnet expedited proposal.

--- a/scripts/makefiles/release.mk
+++ b/scripts/makefiles/release.mk
@@ -11,7 +11,7 @@ WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm/v3 | awk '{print $2}')
 	release-bundle release-s3 release-dev
 
 # Shared with docker.mk for version-aligned testnet/ZK releases
-RELEASE_TAG ?= v5.3.0-dev
+RELEASE_TAG ?= v6.0.0-dev
 # S3 releases bucket folder = project/repo name (see scripts/release/S3-LAYOUT.md)
 PROJECT ?= terp-core
 NETWORK ?= testnet
@@ -207,6 +207,11 @@ create-upgrade-guide:
 			-u $$upgrade_ver \
 			-t $$upgrade_tag; \
 	fi
+
+create-upgrade-guide-v6:
+	python3 scripts/release/create_upgrade_guide/create_upgrade_guide.py \
+		--type coordinated -c v5.2 -u v6 -t v6.0.0 -p $(or $(PROPOSAL_ID),TBD) -b $(or $(UPGRADE_BLOCK),TBD) \
+		--out scripts/release/create_upgrade_guide/v5.2-to-v6.md
 
 ###############################################################################
 # Governance proposal (stub)

--- a/scripts/makefiles/tsh.mk
+++ b/scripts/makefiles/tsh.mk
@@ -15,11 +15,12 @@ tsh-help:
 	@echo "  tsh-staking-hooks 		 Run sh test for staking hook sanity"
 	@echo "  tsh-upgrade 		     Run sh test for upgrade proposal & performance sanity"
 	@echo "  tsh-upgrade-wasm 	     Run sh test: existing wasm guests survive v6 bulk_memory VM"
+	@echo "  tsh-upgrade-cv 	     Run sh test: Cosmovisor auto-swap at v6 halt"
 	@echo "  tsh-zk 			 	 Run sh test for zk-wasmvm module (rick)"
 	@echo "  tsh-hashmerchant 		 Run sh test for hashmerchant vote extensions"
 
 tsh: tsh-help
-tsh-all: tsh-upgrade tsh-upgrade-wasm tsh-staking-hooks tsh-polytone tsh-aa tsh-pfm tsh-ibchook tsh-nfts tsh-zk tsh-hashmerchant
+tsh-all: tsh-upgrade tsh-upgrade-wasm tsh-upgrade-cv tsh-staking-hooks tsh-polytone tsh-aa tsh-pfm tsh-ibchook tsh-nfts tsh-zk tsh-hashmerchant
 tsh-aa: 
 	cd tests/tsh/aa && sh a.sh
 tsh-ibchook: 
@@ -28,6 +29,8 @@ tsh-upgrade:
 	cd tests/tsh/upgrade && sh a.sh
 tsh-upgrade-wasm:
 	cd tests/tsh/upgrade && sh d.sh
+tsh-upgrade-cv:
+	cd tests/tsh/upgrade && sh e.sh
 tsh-staking-hooks: 
 	cd tests/tsh/staking-hooks && sh a.sh
 tsh-polytone: 

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -13,28 +13,28 @@ without drift.
 
 Build ZK images with `WASMVM_SOURCE=local` from this monorepo (`crates/zk-wasmvm`).
 
-## Quick start — `v5.3.0-dev`
+## Quick start — `v6.0.0-dev`
 
 ```bash
 # 1) Branch
-git checkout v5.3.0-dev   # or: git checkout -b v5.3.0-dev
+git checkout v6.0.0-dev
 
 # 2) Build ZK alpine image + tag as v5.3.0-dev (local + ghcr names)
-make docker-publish-dev RELEASE_TAG=v5.3.0-dev
+make docker-publish-dev RELEASE_TAG=v6.0.0-dev
 # Retag only (reuse existing :local-zk without rebuild):
-# make docker-publish-dev RELEASE_TAG=v5.3.0-dev SKIP_BUILD=1
+# make docker-publish-dev RELEASE_TAG=v6.0.0-dev SKIP_BUILD=1
 
 # 3) Push image (needs docker login to containers.terp.network)
-make docker-push-dev RELEASE_TAG=v5.3.0-dev
+make docker-push-dev RELEASE_TAG=v6.0.0-dev
 
 # 4) Bundle source + manifest (local build/release/<tag>/)
-make release-bundle RELEASE_TAG=v5.3.0-dev
+make release-bundle RELEASE_TAG=v6.0.0-dev
 
 # 5) Publish bundle to releases/<project>/<tag>/ on MinIO/S3
 #    PROJECT defaults to terp-core (repo name). MINIO_ALIAS defaults to usb2.
-make release-s3 RELEASE_TAG=v5.3.0-dev PROJECT=terp-core NETWORK=testnet CHAIN_ID=120u-1
+make release-s3 RELEASE_TAG=v6.0.0-dev PROJECT=terp-core NETWORK=testnet CHAIN_ID=120u-1
 # dry-run:
-make release-s3 RELEASE_TAG=v5.3.0-dev DRY_RUN=1
+make release-s3 RELEASE_TAG=v6.0.0-dev DRY_RUN=1
 ```
 
 **S3 layout (all projects):** see [`S3-LAYOUT.md`](./S3-LAYOUT.md) — bucket `releases` → `<project>/<tag>/`.
@@ -62,8 +62,8 @@ Stock mainnet images: `WASMVM_SOURCE=github` strips the two replaces and downloa
 official CosmWasm muslc release.
 
 ```bash
-make docker-publish-dev RELEASE_TAG=v5.3.0-dev
-make docker-push-dev RELEASE_TAG=v5.3.0-dev
+make docker-publish-dev RELEASE_TAG=v6.0.0-dev
+make docker-push-dev RELEASE_TAG=v6.0.0-dev
 ```
 
 ## Scripts
@@ -160,3 +160,17 @@ v3.0.7-zk (or set rust version to 3.0.7 to match v3.0.7).
 Goreleaser linux hooks copy build/wasmvm-release muslc archives when present
 so published linux binaries link the curated ZK muslc instead of the official
 CosmWasm GitHub asset.
+
+
+## Expedited v6 upgrade pack
+
+Plan name on-chain is **`v6`**. Cosmovisor directory: `cosmovisor/upgrades/v6/bin/terpd`.
+
+```bash
+make create-binaries
+make release-prep RELEASE_TAG=v6.0.0
+make create-binaries-json RELEASE_TAG=v6.0.0
+make create-upgrade-guide-v6 PROPOSAL_ID=<id> UPGRADE_BLOCK=<height>
+./scripts/release/create_proposal/submit_proposal.sh --height <H> --tag v6.0.0 --name v6
+make tsh-upgrade-cv   # Cosmovisor auto-swap rehearsal
+```

--- a/scripts/release/create_proposal/PROPOSAL_TEMPLATE.json
+++ b/scripts/release/create_proposal/PROPOSAL_TEMPLATE.json
@@ -1,11 +1,20 @@
 {
-  "title": "Software Upgrade Proposal: ${UPGRADE_NAME}",
-  "description": "Upgrade the Terp Network to ${UPGRADE_NAME}. See full changelog at https://github.com/terpnetwork/terp-core/releases/tag/${UPGRADE_TAG}",
-  "type": "SoftwareUpgrade",
-  "plan": {
-    "name": "${UPGRADE_NAME}",
-    "height": "${UPGRADE_HEIGHT}",
-    "info": "${BINARIES_JSON}"
-  },
-  "deposit": "${DEPOSIT}uterp"
+  "messages": [
+    {
+      "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+      "authority": "${AUTHORITY}",
+      "plan": {
+        "name": "${UPGRADE_NAME}",
+        "time": "0001-01-01T00:00:00Z",
+        "height": "${UPGRADE_HEIGHT}",
+        "info": "${UPGRADE_INFO}",
+        "upgraded_client_state": null
+      }
+    }
+  ],
+  "metadata": "",
+  "deposit": "${DEPOSIT}uterp",
+  "title": "${TITLE}",
+  "summary": "${SUMMARY}",
+  "expedited": true
 }

--- a/scripts/release/create_proposal/submit_proposal.sh
+++ b/scripts/release/create_proposal/submit_proposal.sh
@@ -1,50 +1,77 @@
 #!/usr/bin/env bash
+# Fill PROPOSAL_TEMPLATE.json for an expedited SoftwareUpgrade (v6 by default).
+# Does not broadcast unless --broadcast is passed.
 set -euo pipefail
-
-# submit_proposal.sh — Governance upgrade proposal submission
-#
-# This script will eventually automate the submission of a software upgrade
-# governance proposal to the Terp Network via `terpd tx gov submit-proposal`.
-#
-# Future implementation will:
-#   1. Accept parameters: upgrade name, height, tag, deposit amount, key name
-#   2. Generate the binaries JSON using create_binaries_json.py
-#   3. Fill in PROPOSAL_TEMPLATE.json with the provided values
-#   4. Submit the proposal via:
-#      terpd tx gov submit-proposal software-upgrade <name> \
-#        --title "Upgrade to <name>" \
-#        --description "..." \
-#        --upgrade-height <height> \
-#        --upgrade-info '<binaries_json>' \
-#        --deposit <amount>uterp \
-#        --from <key> \
-#        --chain-id <chain-id> \
-#        --yes
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 
-echo ""
-echo "=== Terp-Core Governance Proposal Submission ==="
-echo ""
-echo "STATUS: Not yet implemented"
-echo ""
-echo "This script will automate governance upgrade proposal submission."
-echo "For now, please submit proposals manually using the terpd CLI."
-echo ""
-echo "Template available at:"
-echo "  ${SCRIPT_DIR}/PROPOSAL_TEMPLATE.json"
-echo ""
-echo "Manual submission example:"
-echo ""
-echo "  terpd tx gov submit-proposal software-upgrade <upgrade-name> \\"
-echo "    --title 'Upgrade to <version>' \\"
-echo "    --description 'See changelog at https://github.com/terpnetwork/terp-core/releases' \\"
-echo "    --upgrade-height <block-height> \\"
-echo "    --upgrade-info '<binaries-json>' \\"
-echo "    --deposit 10000000uterp \\"
-echo "    --from <your-key> \\"
-echo "    --chain-id morocco-1 \\"
-echo "    --yes"
-echo ""
-echo "TODO: Implement automated proposal submission"
-echo ""
+UPGRADE_NAME="${UPGRADE_NAME:-v6}"
+UPGRADE_TAG="${UPGRADE_TAG:-v6.0.0}"
+UPGRADE_HEIGHT="${UPGRADE_HEIGHT:-}"
+DEPOSIT="${DEPOSIT:-5000000000}"
+AUTHORITY="${AUTHORITY:-terp10d07y265gmmuvt4z0w9aw880jnsr700jag6fuq}"
+CHAIN_ID="${CHAIN_ID:-morocco-1}"
+FROM="${FROM:-}"
+BROADCAST=0
+OUT="${OUT:-$ROOT/build/upgrade-proposal-${UPGRADE_NAME}.json}"
+
+usage() {
+  cat <<H
+Usage: $0 --height N [--tag v6.0.0] [--name v6] [--deposit N] [--broadcast] [--from KEY]
+Generates an expedited MsgSoftwareUpgrade JSON (Cosmos SDK v0.50+).
+If --broadcast, submits with terpd (requires --from and a running node).
+H
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --height) UPGRADE_HEIGHT="$2"; shift 2 ;;
+    --tag) UPGRADE_TAG="$2"; shift 2 ;;
+    --name) UPGRADE_NAME="$2"; shift 2 ;;
+    --deposit) DEPOSIT="$2"; shift 2 ;;
+    --from) FROM="$2"; shift 2 ;;
+    --out) OUT="$2"; shift 2 ;;
+    --broadcast) BROADCAST=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown arg $1"; usage; exit 1 ;;
+  esac
+done
+
+if [ -z "$UPGRADE_HEIGHT" ]; then
+  echo "error: --height is required"
+  usage
+  exit 1
+fi
+
+UPGRADE_INFO="${UPGRADE_INFO:-https://github.com/terpnetwork/terp-core/releases/download/${UPGRADE_TAG}/terpd}"
+if [ -f "$ROOT/build/binaries.json" ]; then
+  UPGRADE_INFO=$(python3 -c 'import json,sys; print(json.dumps(json.load(sys.stdin)))' < "$ROOT/build/binaries.json")
+fi
+
+TITLE="${TITLE:-Software Upgrade ${UPGRADE_NAME} (${UPGRADE_TAG})}"
+SUMMARY="${SUMMARY:-Expedited upgrade to ${UPGRADE_TAG}. Plan name ${UPGRADE_NAME}. Pre-place Cosmovisor binary at cosmovisor/upgrades/${UPGRADE_NAME}/bin/terpd.}"
+
+export UPGRADE_NAME UPGRADE_HEIGHT UPGRADE_INFO DEPOSIT AUTHORITY TITLE SUMMARY OUT SCRIPT_DIR
+python3 - <<'PY'
+import json, os
+from pathlib import Path
+raw = (Path(os.environ["SCRIPT_DIR"]) / "PROPOSAL_TEMPLATE.json").read_text()
+for k in ("UPGRADE_NAME", "UPGRADE_HEIGHT", "UPGRADE_INFO", "DEPOSIT", "AUTHORITY", "TITLE", "SUMMARY"):
+    raw = raw.replace("${" + k + "}", os.environ[k])
+obj = json.loads(raw)
+info = os.environ["UPGRADE_INFO"]
+if info.startswith("{"):
+    obj["messages"][0]["plan"]["info"] = info
+out = Path(os.environ["OUT"])
+out.parent.mkdir(parents=True, exist_ok=True)
+out.write_text(json.dumps(obj, indent=2) + "\n")
+print("wrote", out)
+PY
+
+if [ "$BROADCAST" = "1" ]; then
+  [ -n "$FROM" ] || { echo "--broadcast requires --from"; exit 1; }
+  terpd tx gov submit-proposal "$OUT" --from "$FROM" --chain-id "$CHAIN_ID" --gas auto --gas-adjustment 1.5 -y
+else
+  echo "Not broadcasting. Review $OUT then:"
+  echo "  terpd tx gov submit-proposal $OUT --from <key> --chain-id $CHAIN_ID --gas auto --gas-adjustment 1.5 -y"
+fi

--- a/scripts/release/create_upgrade_guide/ROLLING_UPGRADE_TEMPLATE.md
+++ b/scripts/release/create_upgrade_guide/ROLLING_UPGRADE_TEMPLATE.md
@@ -2,76 +2,63 @@
 
 ## Overview
 
-This is a **non-breaking rolling upgrade**. No governance proposal is required. Validators are reccomended to upgarde at their earliest convenience.
+This is a **non-breaking rolling upgrade**. No governance proposal is required.
+Validators should upgrade at their earliest convenience.
 
-- **Upgrade Version**: $UPGRADE_VERSION
-- **Upgrade Tag**: $UPGRADE_TAG
-- **Release**: [GitHub Release](https://github.com/terpnetwork/terp-core/releases/tag/$UPGRADE_TAG)
+- **Upgrade version**: $UPGRADE_VERSION
+- **Upgrade tag**: $UPGRADE_TAG
+- **Release**: [GitHub](https://github.com/terpnetwork/terp-core/releases/tag/$UPGRADE_TAG) · [S3](https://s3.terp.network/releases/terp-core/$UPGRADE_TAG/)
 
-## Binary Downloads
-
-Pre-built binaries are available on the [release page](https://github.com/terpnetwork/terp-core/releases/tag/$UPGRADE_TAG):
+## Binary downloads
 
 | Platform | Architecture | Download |
 |----------|-------------|----------|
-| Linux    | amd64       | [terpd-linux-amd64](https://github.com/terpnetwork/terp-core/releases/download/$UPGRADE_TAG/terpd-linux-amd64) |
-| Linux    | arm64       | [terpd-linux-arm64](https://github.com/terpnetwork/terp-core/releases/download/$UPGRADE_TAG/terpd-linux-arm64) |
+| Linux    | amd64       | [GitHub](https://github.com/terpnetwork/terp-core/releases/download/$UPGRADE_TAG/terpd-linux-amd64) · [S3](https://s3.terp.network/releases/terp-core/$UPGRADE_TAG/terpd-linux-amd64.tar.gz) |
+| Linux    | arm64       | [GitHub](https://github.com/terpnetwork/terp-core/releases/download/$UPGRADE_TAG/terpd-linux-arm64) · [S3](https://s3.terp.network/releases/terp-core/$UPGRADE_TAG/terpd-linux-arm64.tar.gz) |
 
-## Upgrade Steps
+## Upgrade steps
 
-### Option 1: Build from Source
+### Option 1: Build from source
 
 ```sh
-cd $HOME/terp-core
-git pull
+cd "$HOME/terp-core"
+git fetch --tags
 git checkout $UPGRADE_TAG
 make install
 ```
 
-Restart the terpd daemon after building.
+Restart `terpd`.
 
-### Option 2: Download Pre-built Binary
+### Option 2: Pre-built binary
 
 ```sh
-# For amd64:
 wget https://github.com/terpnetwork/terp-core/releases/download/$UPGRADE_TAG/terpd-linux-amd64 -O terpd
 chmod +x terpd
 sudo mv terpd /usr/local/bin/
-
-# For arm64:
-wget https://github.com/terpnetwork/terp-core/releases/download/$UPGRADE_TAG/terpd-linux-arm64 -O terpd
-chmod +x terpd
-sudo mv terpd /usr/local/bin/
 ```
-
-Restart the terpd daemon after replacing the binary.
 
 ### Option 3: Cosmovisor
 
-If you use Cosmovisor, place the new binary in the upgrades directory:
-
 ```sh
+go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.7.1
 mkdir -p ~/.terpd/cosmovisor/upgrades/$UPGRADE_VERSION/bin
-cd $HOME/terp-core
-git pull
-git checkout $UPGRADE_TAG
-make build
-cp build/terpd ~/.terpd/cosmovisor/upgrades/$UPGRADE_VERSION/bin
+cd "$HOME/terp-core" && git fetch --tags && git checkout $UPGRADE_TAG && make build
+cp build/terpd ~/.terpd/cosmovisor/upgrades/$UPGRADE_VERSION/bin/terpd
 ```
 
-## Verification
+Folder name `$UPGRADE_VERSION` must match the on-chain plan name if this later becomes a coordinated halt.
 
-After upgrading, verify the version:
+## Verification
 
 ```sh
 terpd version
 ```
 
-Expected output should include version `$UPGRADE_TAG`.
+Expected: `$UPGRADE_TAG`.
 
 ---
 
-## Additional Resources
+## Additional resources
 
-- Terp Network Documentation: [Website](https://docs.terp.network)
-- Community Support: [Discord](https://discord.gg/pAxjcFnAFH)
+- Docs: https://docs.terp.network
+- Discord: https://discord.gg/pAxjcFnAFH

--- a/scripts/release/create_upgrade_guide/UPGRADE_TEMPLATE.md
+++ b/scripts/release/create_upgrade_guide/UPGRADE_TEMPLATE.md
@@ -2,88 +2,102 @@
 
 ## Overview
 
-- **$UPGRADE_VERSION Proposal**: [Proposal Page](https://www.ping.pub/terp/gov/$PROPOSAL_ID)
-- **$UPGRADE_VERSION Upgrade Block Height**: $UPGRADE_BLOCK
-- **$UPGRADE_VERSION Upgrade Countdown**: [Block Countdown](https://testnet.itrocket.net/terp/block/$UPGRADE_BLOCK)
+This is a **coordinated, expedited** software upgrade. Validators **must** halt at
+the upgrade height and restart with the `$UPGRADE_TAG` binary (Cosmovisor does
+this automatically if the upgrade binary is pre-placed).
+
+- **Plan name** (must match `app/upgrades`): `$UPGRADE_VERSION`
+- **Git tag / binary**: `$UPGRADE_TAG`
+- **$UPGRADE_VERSION proposal**: [Gov](https://www.ping.pub/terp/gov/$PROPOSAL_ID)
+- **Upgrade height**: `$UPGRADE_BLOCK`
+- **Countdown**: [Block countdown](https://www.ping.pub/terp/block/$UPGRADE_BLOCK)
+- **Release**: [GitHub](https://github.com/terpnetwork/terp-core/releases/tag/$UPGRADE_TAG) · [S3](https://s3.terp.network/releases/terp-core/$UPGRADE_TAG/)
 
 ---
 
-## Cosmovisor Configuration
+## Cosmovisor (recommended)
 
-### Initial Setup (For First-Time Users)
+Cosmovisor swaps `terpd` at the on-chain plan name (`$UPGRADE_VERSION`). Docs:
+[Cosmovisor](https://docs.cosmos.network/main/tooling/cosmovisor).
 
-If you have not previously configured Cosmovisor, follow this section; otherwise, proceed to the next section.
-
-Cosmovisor is strongly recommended for validators to minimize downtime during upgrades. It automates the binary replacement process according to on-chain `SoftwareUpgrade` proposals.
-
-Documentation for Cosmovisor can be found [here](https://docs.cosmos.network/main/tooling/cosmovisor).
-
-#### Installation Steps
-
-*Run these commands to install and configure Cosmovisor*:
+### Install (first time)
 
 ```sh
-go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@latest
-mkdir -p ~/.terpd
-mkdir -p ~/.terpd/cosmovisor
-mkdir -p ~/.terpd/cosmovisor/genesis
+# SDK 0.50+ module path (do not use github.com/cosmos/cosmos-sdk/cosmovisor@v1.0.0)
+go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.7.1
+
 mkdir -p ~/.terpd/cosmovisor/genesis/bin
 mkdir -p ~/.terpd/cosmovisor/upgrades
-cp $GOPATH/bin/terpd ~/.terpd/cosmovisor/genesis/bin
-mkdir -p ~/.terpd/cosmovisor/upgrades/$CURRENT_VERSION/bin
-cp $GOPATH/bin/terpd ~/.terpd/cosmovisor/upgrades/$CURRENT_VERSION/bin
-```
 
-*Add these lines to your profile to set up environment variables*:
+# Current (pre-upgrade) binary is genesis + current plan folder
+cp "$(command -v terpd)" ~/.terpd/cosmovisor/genesis/bin/terpd
+mkdir -p ~/.terpd/cosmovisor/upgrades/$CURRENT_VERSION/bin
+cp "$(command -v terpd)" ~/.terpd/cosmovisor/upgrades/$CURRENT_VERSION/bin/terpd
+```
 
 ```sh
-echo "# Cosmovisor Setup" >> ~/.profile
-echo "export DAEMON_NAME=terpd" >> ~/.profile
-echo "export DAEMON_HOME=$HOME/.terpd" >> ~/.profile
-echo "export DAEMON_ALLOW_DOWNLOAD_BINARIES=false" >> ~/.profile
-echo "export DAEMON_LOG_BUFFER_SIZE=512" >> ~/.profile
-echo "export DAEMON_RESTART_AFTER_UPGRADE=true" >> ~/.profile
-echo "export UNSAFE_SKIP_BACKUP=true" >> ~/.profile
-source ~/.profile
+export DAEMON_NAME=terpd
+export DAEMON_HOME="$HOME/.terpd"
+export DAEMON_ALLOW_DOWNLOAD_BINARIES=false
+export DAEMON_RESTART_AFTER_UPGRADE=true
+export DAEMON_POLL_INTERVAL=300ms
+export UNSAFE_SKIP_BACKUP=true
+# persist in ~/.profile as needed
 ```
 
-### Upgrading to $UPGRADE_VERSION
+Run the node **through** Cosmovisor, not raw `terpd start`:
 
-*To prepare for the upgrade, execute these commands*:
+```sh
+cosmovisor run start
+```
+
+### Pre-place the $UPGRADE_VERSION binary (before halt)
+
+Plan directory name **must** equal the on-chain upgrade name (`$UPGRADE_VERSION`, not the git tag).
 
 ```sh
 mkdir -p ~/.terpd/cosmovisor/upgrades/$UPGRADE_VERSION/bin
-cd $HOME/terp-core
-git pull
-git checkout $UPGRADE_TAG
-make build
-cp build/terpd ~/.terpd/cosmovisor/upgrades/$UPGRADE_VERSION/bin
+# from source:
+cd "$HOME/terp-core" && git fetch --tags && git checkout $UPGRADE_TAG && make build
+cp build/terpd ~/.terpd/cosmovisor/upgrades/$UPGRADE_VERSION/bin/terpd
+# or from S3 / GitHub release tarball, then:
+# cp terpd ~/.terpd/cosmovisor/upgrades/$UPGRADE_VERSION/bin/terpd
+chmod +x ~/.terpd/cosmovisor/upgrades/$UPGRADE_VERSION/bin/terpd
+~/.terpd/cosmovisor/upgrades/$UPGRADE_VERSION/bin/terpd version
 ```
 
-At the designated block height, Cosmovisor will automatically upgrade to version $UPGRADE_VERSION.
+At height `$UPGRADE_BLOCK` Cosmovisor restarts into `$UPGRADE_VERSION` without a manual binary swap.
 
 ---
 
-## Manual Upgrade Procedure
+## Manual upgrade (no Cosmovisor)
 
-Follow these steps if you opt for a manual upgrade:
-
-1. Monitor Terp Network until it reaches the specified upgrade block height: $UPGRADE_BLOCK.
-2. Observe for a panic message followed by continuous peer logs, then halt the daemon.
-3. Perform these steps:
+1. Wait for height `$UPGRADE_BLOCK` and `UPGRADE "$UPGRADE_VERSION" NEEDED`.
+2. Stop `terpd`.
+3. Install `$UPGRADE_TAG` and start again:
 
 ```sh
-cd $HOME/terp-core
-git pull
+cd "$HOME/terp-core"
+git fetch --tags
 git checkout $UPGRADE_TAG
 make install
+terpd start
 ```
-
-4. Restart the Terp-Core daemon and observe the upgrade.
 
 ---
 
-## Additional Resources
+## Binaries
 
-- Terp Network Documentation: [Website](https://docs.terp.network)
-- Community Support: [Discord](https://discord.gg/pAxjcFnAFH)
+| Platform | Artifact |
+|----------|----------|
+| linux/amd64 | [GitHub](https://github.com/terpnetwork/terp-core/releases/download/$UPGRADE_TAG/terpd-linux-amd64) · [S3 tarball](https://s3.terp.network/releases/terp-core/$UPGRADE_TAG/terpd-linux-amd64.tar.gz) |
+| linux/arm64 | [GitHub](https://github.com/terpnetwork/terp-core/releases/download/$UPGRADE_TAG/terpd-linux-arm64) · [S3 tarball](https://s3.terp.network/releases/terp-core/$UPGRADE_TAG/terpd-linux-arm64.tar.gz) |
+
+`make create-binaries-json RELEASE_TAG=$UPGRADE_TAG` emits Cosmovisor `upgrade-info` JSON.
+
+---
+
+## Additional resources
+
+- Docs: https://docs.terp.network
+- Discord: https://discord.gg/pAxjcFnAFH

--- a/scripts/release/create_upgrade_guide/UPGRADE_TEMPLATE.md
+++ b/scripts/release/create_upgrade_guide/UPGRADE_TEMPLATE.md
@@ -42,6 +42,7 @@ export DAEMON_ALLOW_DOWNLOAD_BINARIES=false
 export DAEMON_RESTART_AFTER_UPGRADE=true
 export DAEMON_POLL_INTERVAL=300ms
 export UNSAFE_SKIP_BACKUP=true
+export DAEMON_DATA_BACKUP_DIR="$HOME/.terpd/data-backup"
 # persist in ~/.profile as needed
 ```
 

--- a/scripts/release/create_upgrade_guide/create_upgrade_guide.py
+++ b/scripts/release/create_upgrade_guide/create_upgrade_guide.py
@@ -58,6 +58,8 @@ def main():
                         help='Proposal ID (required for coordinated upgrades)')
     parser.add_argument('--upgrade_block', '-b', metavar='upgrade_block', type=str, required=False,
                         help='Upgrade block height (required for coordinated upgrades)')
+    parser.add_argument('--out', '-o', metavar='path', type=str, required=False,
+                        help='Write guide to this path instead of stdout')
 
     args = parser.parse_args()
 
@@ -96,7 +98,16 @@ def main():
         substitutions['UPGRADE_BLOCK'] = args.upgrade_block
 
     filled_markdown = t.safe_substitute(**substitutions)
-    print(filled_markdown)
+    if args.out:
+        out_path = args.out
+        os.makedirs(os.path.dirname(os.path.abspath(out_path)) or '.', exist_ok=True)
+        with open(out_path, 'w') as fh:
+            fh.write(filled_markdown)
+            if not filled_markdown.endswith('\n'):
+                fh.write('\n')
+        print(f'wrote {out_path}')
+    else:
+        print(filled_markdown)
 
 
 if __name__ == "__main__":

--- a/scripts/release/create_upgrade_guide/v5.2-to-v6.md
+++ b/scripts/release/create_upgrade_guide/v5.2-to-v6.md
@@ -1,0 +1,103 @@
+# Mainnet Upgrade Guide: From Version v5.2 to v6
+
+## Overview
+
+This is a **coordinated, expedited** software upgrade. Validators **must** halt at
+the upgrade height and restart with the `v6.0.0` binary (Cosmovisor does
+this automatically if the upgrade binary is pre-placed).
+
+- **Plan name** (must match `app/upgrades`): `v6`
+- **Git tag / binary**: `v6.0.0`
+- **v6 proposal**: [Gov](https://www.ping.pub/terp/gov/TBD)
+- **Upgrade height**: `TBD`
+- **Countdown**: [Block countdown](https://www.ping.pub/terp/block/TBD)
+- **Release**: [GitHub](https://github.com/terpnetwork/terp-core/releases/tag/v6.0.0) · [S3](https://s3.terp.network/releases/terp-core/v6.0.0/)
+
+---
+
+## Cosmovisor (recommended)
+
+Cosmovisor swaps `terpd` at the on-chain plan name (`v6`). Docs:
+[Cosmovisor](https://docs.cosmos.network/main/tooling/cosmovisor).
+
+### Install (first time)
+
+```sh
+# SDK 0.50+ module path (do not use github.com/cosmos/cosmos-sdk/cosmovisor@v1.0.0)
+go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.7.1
+
+mkdir -p ~/.terpd/cosmovisor/genesis/bin
+mkdir -p ~/.terpd/cosmovisor/upgrades
+
+# Current (pre-upgrade) binary is genesis + current plan folder
+cp "$(command -v terpd)" ~/.terpd/cosmovisor/genesis/bin/terpd
+mkdir -p ~/.terpd/cosmovisor/upgrades/v5.2/bin
+cp "$(command -v terpd)" ~/.terpd/cosmovisor/upgrades/v5.2/bin/terpd
+```
+
+```sh
+export DAEMON_NAME=terpd
+export DAEMON_HOME="$HOME/.terpd"
+export DAEMON_ALLOW_DOWNLOAD_BINARIES=false
+export DAEMON_RESTART_AFTER_UPGRADE=true
+export DAEMON_POLL_INTERVAL=300ms
+export UNSAFE_SKIP_BACKUP=true
+# persist in ~/.profile as needed
+```
+
+Run the node **through** Cosmovisor, not raw `terpd start`:
+
+```sh
+cosmovisor run start
+```
+
+### Pre-place the v6 binary (before halt)
+
+Plan directory name **must** equal the on-chain upgrade name (`v6`, not the git tag).
+
+```sh
+mkdir -p ~/.terpd/cosmovisor/upgrades/v6/bin
+# from source:
+cd "$HOME/terp-core" && git fetch --tags && git checkout v6.0.0 && make build
+cp build/terpd ~/.terpd/cosmovisor/upgrades/v6/bin/terpd
+# or from S3 / GitHub release tarball, then:
+# cp terpd ~/.terpd/cosmovisor/upgrades/v6/bin/terpd
+chmod +x ~/.terpd/cosmovisor/upgrades/v6/bin/terpd
+~/.terpd/cosmovisor/upgrades/v6/bin/terpd version
+```
+
+At height `TBD` Cosmovisor restarts into `v6` without a manual binary swap.
+
+---
+
+## Manual upgrade (no Cosmovisor)
+
+1. Wait for height `TBD` and `UPGRADE "v6" NEEDED`.
+2. Stop `terpd`.
+3. Install `v6.0.0` and start again:
+
+```sh
+cd "$HOME/terp-core"
+git fetch --tags
+git checkout v6.0.0
+make install
+terpd start
+```
+
+---
+
+## Binaries
+
+| Platform | Artifact |
+|----------|----------|
+| linux/amd64 | [GitHub](https://github.com/terpnetwork/terp-core/releases/download/v6.0.0/terpd-linux-amd64) · [S3 tarball](https://s3.terp.network/releases/terp-core/v6.0.0/terpd-linux-amd64.tar.gz) |
+| linux/arm64 | [GitHub](https://github.com/terpnetwork/terp-core/releases/download/v6.0.0/terpd-linux-arm64) · [S3 tarball](https://s3.terp.network/releases/terp-core/v6.0.0/terpd-linux-arm64.tar.gz) |
+
+`make create-binaries-json RELEASE_TAG=v6.0.0` emits Cosmovisor `upgrade-info` JSON.
+
+---
+
+## Additional resources
+
+- Docs: https://docs.terp.network
+- Discord: https://discord.gg/pAxjcFnAFH

--- a/scripts/release/create_upgrade_guide/v5.2-to-v6.md
+++ b/scripts/release/create_upgrade_guide/v5.2-to-v6.md
@@ -42,6 +42,7 @@ export DAEMON_ALLOW_DOWNLOAD_BINARIES=false
 export DAEMON_RESTART_AFTER_UPGRADE=true
 export DAEMON_POLL_INTERVAL=300ms
 export UNSAFE_SKIP_BACKUP=true
+export DAEMON_DATA_BACKUP_DIR="$HOME/.terpd/data-backup"
 # persist in ~/.profile as needed
 ```
 

--- a/tests/tsh/upgrade/README.md
+++ b/tests/tsh/upgrade/README.md
@@ -19,3 +19,15 @@ sh d.sh
 
 Claim if it exits 0: updating the VM to support bulk memory does not brick
 existing smart contracts from working.
+
+
+## E — Cosmovisor auto-swap at v6
+
+Mirrors `b.sh` but starts the node with **Cosmovisor**. Genesis binary is
+`terp-mainnet`; `upgrades/v6/bin/terpd` is this tree. The process must stay up
+across halt.
+
+```sh
+make tsh-upgrade-cv
+# or: SKIP_INSTALL=1 sh e.sh
+```

--- a/tests/tsh/upgrade/e.sh
+++ b/tests/tsh/upgrade/e.sh
@@ -192,7 +192,16 @@ for i in $(seq 1 180); do
     exit 1
   fi
   if grep -q "UPGRADE \"${UPGRADE_VERSION_TITLE}\" NEEDED" "$CV_LOG" 2>/dev/null; then
+    if [ "$SAW_NEEDED" != "1" ]; then
+      echo "E: saw UPGRADE NEEDED — if the old daemon does not exit, SIGTERM the child so Cosmovisor can swap"
+    fi
     SAW_NEEDED=1
+  fi
+  # 5.2.0 can panic-without-exit; Cosmovisor only swaps after the child dies.
+  if [ "$SAW_NEEDED" = "1" ] && [ "${SENT_TERM:-0}" != "1" ] && [ "$i" -ge 20 ]; then
+    echo "E: sending SIGTERM to Cosmovisor child (old terpd) so parent can exec upgrades/v6"
+    pkill -TERM -P "$CV_PID" 2>/dev/null || true
+    SENT_TERM=1
   fi
   APPLIED_H=$(applied_height || true)
   h=$(rpc_height || echo 0)

--- a/tests/tsh/upgrade/e.sh
+++ b/tests/tsh/upgrade/e.sh
@@ -140,6 +140,8 @@ export DAEMON_ALLOW_DOWNLOAD_BINARIES=false
 export DAEMON_RESTART_AFTER_UPGRADE=true
 export DAEMON_POLL_INTERVAL=300ms
 export UNSAFE_SKIP_BACKUP=true
+export DAEMON_DATA_BACKUP_DIR="$HOME_DIR/data-backup"
+mkdir -p "$DAEMON_DATA_BACKUP_DIR"
 
 : > "$CV_LOG"
 "$CV_BIND" run start --home "$HOME_DIR" --pruning=nothing --minimum-gas-prices=0uterp \

--- a/tests/tsh/upgrade/e.sh
+++ b/tests/tsh/upgrade/e.sh
@@ -199,11 +199,18 @@ for i in $(seq 1 180); do
     fi
     SAW_NEEDED=1
   fi
-  # 5.2.0 can panic-without-exit; Cosmovisor only swaps after the child dies.
-  if [ "$SAW_NEEDED" = "1" ] && [ "${SENT_TERM:-0}" != "1" ] && [ "$i" -ge 20 ]; then
-    echo "E: sending SIGTERM to Cosmovisor child (old terpd) so parent can exec upgrades/v6"
-    pkill -TERM -P "$CV_PID" 2>/dev/null || true
-    SENT_TERM=1
+  # 5.2.0 panics without exiting. Cosmovisor v1.7 then does not swap until
+  # the wrapper is restarted (same as systemd Restart=always).
+  if [ "$SAW_NEEDED" = "1" ] && [ "${CV_RESTARTED:-0}" != "1" ] && [ "$i" -ge 15 ]; then
+    echo "E: restarting Cosmovisor so it picks upgrades/v6 from upgrade-info.json"
+    kill "$CV_PID" 2>/dev/null || true
+    wait "$CV_PID" 2>/dev/null || true
+    sleep 2
+    "$CV_BIND" run start --home "$HOME_DIR" --pruning=nothing --minimum-gas-prices=0uterp \
+      --rpc.laddr="tcp://127.0.0.1:$RPC" ${WASMVM_SKIP:+--wasm.skip_wasmvm_version_check} >>"$CV_LOG" 2>&1 &
+    CV_PID=$!
+    CV_RESTARTED=1
+    wait_rpc || true
   fi
   APPLIED_H=$(applied_height || true)
   h=$(rpc_height || echo 0)

--- a/tests/tsh/upgrade/e.sh
+++ b/tests/tsh/upgrade/e.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+####################################################################
+# TEST E: Cosmovisor performs the v6 upgrade (no manual binary restart).
+#
+# Mirrors b.sh (local genesis + expedited gov software-upgrade named v6):
+#   genesis bin  = OLD_BIND (current mainnet, no v6 handler)
+#   upgrades/v6  = NEW_BIND (this tree)
+#   start via `cosmovisor run start`
+#   after halt, Cosmovisor must restart the new binary and apply v6
+#
+# Does not include parallel feature work (hashmerchant product, lean, etc.).
+####################################################################
+set -euo pipefail
+export PATH="/usr/local/go/bin:/usr/local/bin:/opt/homebrew/bin:${HOME}/go/bin:${PATH}"
+
+OLD_BIND="${OLD_BIND:-terp-mainnet}"
+NEW_BIND="${NEW_BIND:-terpd}"
+CV_BIND="${CV_BIND:-cosmovisor}"
+UPGRADE_INFO_URL="${UPGRADE_INFO_URL:-https://github.com/terpnetwork/terp-core/releases/download/v6.0.0/terpd}"
+UPGRADE_VERSION_TITLE="${UPGRADE_VERSION_TITLE:-v6}"
+KEY="${KEY:-terp1}"
+KEY2="${KEY2:-terp2}"
+NEW_RELEASE_PATH="${NEW_RELEASE_PATH:-../../../}"
+CHAIN_ID="${CHAIN_ID:-local-cv-upgrade}"
+MONIKER="${MONIKER:-localterp-e}"
+DENOM="${DENOM:-uterp}"
+KEYALGO="${KEYALGO:-secp256k1}"
+KEYRING="${KEYRING:-test}"
+HOME_DIR="${HOME_DIR:-$HOME/.terpd-e}"
+CLEAN="${CLEAN:-true}"
+RPC="${RPC:-27757}"
+REST="${REST:-1328}"
+P2P="${P2P:-27756}"
+GRPC="${GRPC:-9098}"
+TIMEOUT_COMMIT="${TIMEOUT_COMMIT:-1s}"
+HALT_DELTA="${HALT_DELTA:-14}"
+POST_BLOCKS="${POST_BLOCKS:-5}"
+CV_LOG="${CV_LOG:-/tmp/tsh-e-cv.log}"
+CV_PID=""
+NODE="tcp://127.0.0.1:${RPC}"
+
+command -v "$OLD_BIND" >/dev/null || { echo "$OLD_BIND not found"; exit 1; }
+command -v jq >/dev/null || { echo "jq required"; exit 1; }
+
+rpc() { curl -sf "http://127.0.0.1:${RPC}/status"; }
+rpc_height() { rpc | jq -r ".result.sync_info.latest_block_height"; }
+wait_rpc() {
+  for _ in $(seq 1 90); do
+    cid=$(rpc 2>/dev/null | jq -r ".result.node_info.network // empty") || true
+    if [ "$cid" = "$CHAIN_ID" ]; then return 0; fi
+    sleep 1
+  done
+  echo "RPC down or wrong chain (want $CHAIN_ID)"; tail -50 "$CV_LOG"; return 1
+}
+
+applied_height() {
+  "$NEW_BIND" q upgrade applied "$UPGRADE_VERSION_TITLE" \
+    --home "$HOME_DIR" --node "$NODE" -o json 2>/dev/null \
+    | jq -r ".height // empty"
+}
+
+tune_config() {
+  local cfg="$HOME_DIR/config/config.toml"
+  sed -i.bak "/^\[rpc\]/,/^\[/ s/^laddr *=.*/laddr = \"tcp:\/\/127.0.0.1:${RPC}\"/" "$cfg"
+  sed -i.bak "/^\[rpc\]/,/^\[/ s/^pprof_laddr *=.*/pprof_laddr = \"localhost:16063\"/" "$cfg"
+  sed -i.bak "/^\[p2p\]/,/^\[/ s/^laddr *=.*/laddr = \"tcp:\/\/127.0.0.1:${P2P}\"/" "$cfg"
+  sed -i.bak "/^\[p2p\]/,/^\[/ s/^pex *=.*/pex = false/" "$cfg"
+  sed -i.bak "/^\[p2p\]/,/^\[/ s/^seeds *=.*/seeds = \"\"/" "$cfg"
+  sed -i.bak "/^\[p2p\]/,/^\[/ s/^persistent_peers *=.*/persistent_peers = \"\"/" "$cfg"
+  sed -i.bak "/^\[consensus\]/,/^\[/ s/^[[:space:]]*timeout_commit[[:space:]]*=.*/timeout_commit = \"${TIMEOUT_COMMIT}\"/" "$cfg"
+  sed -i.bak "/^\[api\]/,/^\[/ s/address.*/address = \"tcp:\/\/127.0.0.1:${REST}\"/" "$HOME_DIR/config/app.toml" || true
+  sed -i.bak "/^\[grpc\]/,/^\[/ s/address.*/address = \"localhost:${GRPC}\"/" "$HOME_DIR/config/app.toml" || true
+}
+
+from_scratch() {
+  rm -rf "$HOME_DIR"
+  echo "decorate bright ozone fork gallery riot bus exhaust worth way bone indoor calm squirrel merry zero scheme cotton until shop any excess stage laundry" | \
+    "$OLD_BIND" keys add "$KEY" --home "$HOME_DIR" --keyring-backend "$KEYRING" --algo "$KEYALGO" --recover
+  echo "wealth flavor believe regret funny network recall kiss grape useless pepper cram hint member few certain unveil rather brick bargain curious require crowd raise" | \
+    "$OLD_BIND" keys add "$KEY2" --home "$HOME_DIR" --keyring-backend "$KEYRING" --algo "$KEYALGO" --recover
+  "$OLD_BIND" init "$MONIKER" --home "$HOME_DIR" --chain-id "$CHAIN_ID" --default-denom "$DENOM"
+  update_test_genesis() {
+    jq "$1" "$HOME_DIR/config/genesis.json" > "$HOME_DIR/config/tmp_genesis.json"
+    mv "$HOME_DIR/config/tmp_genesis.json" "$HOME_DIR/config/genesis.json"
+  }
+  update_test_genesis ".consensus.params.block.max_gas=\"100000000\""
+  update_test_genesis ".app_state.gov.params.min_deposit=[{\"denom\":\"uterp\",\"amount\":\"1000000\"}]"
+  update_test_genesis ".app_state.gov.params.voting_period=\"15s\""
+  update_test_genesis ".app_state.gov.params.expedited_voting_period=\"5s\""
+  update_test_genesis ".app_state.staking.params.bond_denom=\"uterp\""
+  update_test_genesis ".app_state.mint.params.mint_denom=\"uterp\""
+  "$OLD_BIND" genesis add-genesis-account "$KEY" 1000000000000uterp,1000uthiol --home "$HOME_DIR" --keyring-backend "$KEYRING"
+  "$OLD_BIND" genesis add-genesis-account "$KEY2" 100000000000uterp,1000uthiol --home "$HOME_DIR" --keyring-backend "$KEYRING"
+  "$OLD_BIND" genesis gentx "$KEY" 10000000000uterp --home "$HOME_DIR" --keyring-backend "$KEYRING" --chain-id "$CHAIN_ID"
+  "$OLD_BIND" genesis collect-gentxs --home "$HOME_DIR"
+  "$OLD_BIND" genesis validate --home "$HOME_DIR"
+}
+
+setup_cosmovisor() {
+  if ! command -v "$CV_BIND" >/dev/null; then
+    echo "E: installing cosmossdk.io/tools/cosmovisor@v1.7.1"
+    go install cosmossdk.io/tools/cosmovisor/cmd/cosmovisor@v1.7.1
+  fi
+  command -v "$CV_BIND" >/dev/null || { echo "cosmovisor not on PATH"; exit 1; }
+  echo "E: cosmovisor $($CV_BIND version 2>/dev/null | head -1 || echo ok)"
+
+  local old_bin new_bin
+  old_bin=$(command -v "$OLD_BIND")
+  new_bin=$(command -v "$NEW_BIND")
+  mkdir -p "$HOME_DIR/cosmovisor/genesis/bin"
+  mkdir -p "$HOME_DIR/cosmovisor/upgrades/${UPGRADE_VERSION_TITLE}/bin"
+  cp "$old_bin" "$HOME_DIR/cosmovisor/genesis/bin/terpd"
+  cp "$new_bin" "$HOME_DIR/cosmovisor/upgrades/${UPGRADE_VERSION_TITLE}/bin/terpd"
+  chmod +x "$HOME_DIR/cosmovisor/genesis/bin/terpd"
+  chmod +x "$HOME_DIR/cosmovisor/upgrades/${UPGRADE_VERSION_TITLE}/bin/terpd"
+  echo "E: genesis=$old_bin upgrades/${UPGRADE_VERSION_TITLE}=$new_bin"
+}
+
+cleanup() { kill "${CV_PID:-}" 2>/dev/null || true; }
+trap cleanup EXIT
+
+if [ "${SKIP_INSTALL:-0}" = "1" ]; then
+  echo "E: SKIP_INSTALL=1 — using existing $NEW_BIND"
+else
+  echo "E: make install NEW_BIND=$NEW_BIND"
+  ( cd "$NEW_RELEASE_PATH" && make install )
+fi
+command -v "$NEW_BIND" >/dev/null || { echo "$NEW_BIND not on PATH"; exit 1; }
+echo "E: OLD=$OLD_BIND ($("$OLD_BIND" version | head -1)) NEW=$NEW_BIND ($("$NEW_BIND" version | head -1))"
+
+if [ "$CLEAN" != "false" ]; then
+  from_scratch
+  tune_config
+fi
+setup_cosmovisor
+
+export DAEMON_NAME=terpd
+export DAEMON_HOME="$HOME_DIR"
+export DAEMON_ALLOW_DOWNLOAD_BINARIES=false
+export DAEMON_RESTART_AFTER_UPGRADE=true
+export DAEMON_POLL_INTERVAL=300ms
+export UNSAFE_SKIP_BACKUP=true
+
+: > "$CV_LOG"
+"$CV_BIND" run start --home "$HOME_DIR" --pruning=nothing --minimum-gas-prices=0uterp \
+  --rpc.laddr="tcp://127.0.0.1:$RPC" ${WASMVM_SKIP:+--wasm.skip_wasmvm_version_check} >>"$CV_LOG" 2>&1 &
+CV_PID=$!
+wait_rpc
+sleep 2
+H0=$(rpc_height)
+HALT=$((H0 + HALT_DELTA))
+echo "E: proposing $UPGRADE_VERSION_TITLE at height $HALT (now $H0) cv_pid=$CV_PID"
+
+cat > "$HOME_DIR/upgrade.json" <<JSON
+{
+  "messages": [
+    {
+      "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+      "authority": "terp10d07y265gmmuvt4z0w9aw880jnsr700jag6fuq",
+      "plan": {
+        "name": "$UPGRADE_VERSION_TITLE",
+        "time": "0001-01-01T00:00:00Z",
+        "height": "$HALT",
+        "info": "$UPGRADE_INFO_URL",
+        "upgraded_client_state": null
+      }
+    }
+  ],
+  "metadata": "",
+  "deposit": "5000000000$DENOM",
+  "title": "$UPGRADE_VERSION_TITLE",
+  "summary": "expedited v6; Cosmovisor must swap binaries",
+  "expedited": true
+}
+JSON
+
+"$OLD_BIND" tx gov submit-proposal "$HOME_DIR/upgrade.json" --from "$KEY" --home "$HOME_DIR" \
+  --chain-id "$CHAIN_ID" --keyring-backend "$KEYRING" --node "$NODE" \
+  --gas auto --gas-adjustment 1.5 --fees "2000$DENOM" -y
+sleep 2
+"$OLD_BIND" tx gov vote 1 yes --from "$KEY" --home "$HOME_DIR" --chain-id "$CHAIN_ID" \
+  --keyring-backend "$KEYRING" --node "$NODE" --gas auto --gas-adjustment 1.2 --fees "1000$DENOM" -y
+"$OLD_BIND" tx gov vote 1 yes --from "$KEY2" --home "$HOME_DIR" --chain-id "$CHAIN_ID" \
+  --keyring-backend "$KEYRING" --node "$NODE" --gas auto --gas-adjustment 1.2 --fees "1000$DENOM" -y
+
+echo "E: waiting for Cosmovisor to pass halt $HALT (process must keep running)"
+SAW_NEEDED=0
+for i in $(seq 1 180); do
+  if ! kill -0 "$CV_PID" 2>/dev/null; then
+    echo "E: cosmovisor exited unexpectedly"
+    tail -80 "$CV_LOG"
+    exit 1
+  fi
+  if grep -q "UPGRADE \"${UPGRADE_VERSION_TITLE}\" NEEDED" "$CV_LOG" 2>/dev/null; then
+    SAW_NEEDED=1
+  fi
+  APPLIED_H=$(applied_height || true)
+  h=$(rpc_height || echo 0)
+  echo "  cv h=$h applied=${APPLIED_H:-none} needed=$SAW_NEEDED try=$i"
+  if [ -n "${APPLIED_H:-}" ] && [ "$APPLIED_H" != "0" ] && [ "$h" -gt "$HALT" ]; then
+    break
+  fi
+  sleep 1
+done
+
+if [ "$SAW_NEEDED" != "1" ]; then
+  echo "E: never saw UPGRADE NEEDED in cosmovisor log"
+  tail -80 "$CV_LOG"
+  exit 1
+fi
+APPLIED_H=$(applied_height || true)
+if [ -z "${APPLIED_H:-}" ] || [ "$APPLIED_H" = "0" ]; then
+  echo "E: v6 not applied via Cosmovisor"
+  tail -80 "$CV_LOG"
+  exit 1
+fi
+if ! kill -0 "$CV_PID" 2>/dev/null; then
+  echo "E: cosmovisor died after upgrade"
+  tail -80 "$CV_LOG"
+  exit 1
+fi
+
+AFTER=$(rpc_height)
+TARGET=$((AFTER + POST_BLOCKS))
+echo "E: waiting for $POST_BLOCKS post-upgrade blocks (from $AFTER to >= $TARGET)"
+for i in $(seq 1 120); do
+  h=$(rpc_height || echo 0)
+  echo "  post-apply h=$h target=$TARGET try=$i"
+  if [ "$h" -ge "$TARGET" ]; then break; fi
+  if ! kill -0 "$CV_PID" 2>/dev/null; then
+    echo "E: cosmovisor died producing post-upgrade blocks"; tail -50 "$CV_LOG"; exit 1
+  fi
+  sleep 2
+done
+h=$(rpc_height)
+if [ "$h" -lt "$TARGET" ]; then
+  echo "E: did not produce post-upgrade blocks"; exit 1
+fi
+
+if [ -L "$HOME_DIR/cosmovisor/current" ]; then
+  CUR=$(readlink "$HOME_DIR/cosmovisor/current")
+  echo "E: cosmovisor current -> $CUR"
+  echo "$CUR" | grep -q "$UPGRADE_VERSION_TITLE" || {
+    echo "E: current symlink is not $UPGRADE_VERSION_TITLE"
+    exit 1
+  }
+fi
+
+echo "E: PASS Cosmovisor applied $UPGRADE_VERSION_TITLE at $APPLIED_H height=$h (pid $CV_PID still running)"


### PR DESCRIPTION
## Scope
Upgrade **release assets and rehearsal only**. No lean/hashmerchant/worktree-replace work.

## Tuned for expedited v6
- Plan name **`v6`** (Cosmovisor dir `upgrades/v6/bin/terpd`)
- Guides: Cosmovisor via `cosmossdk.io/tools/cosmovisor@v1.7.1`, S3 + GitHub artifacts
- Expedited `MsgSoftwareUpgrade` JSON: `./scripts/release/create_proposal/submit_proposal.sh --height <H> --tag v6.0.0 --name v6`
- Filled guide: `scripts/release/create_upgrade_guide/v5.2-to-v6.md`
- `RELEASE_TAG` default `v6.0.0-dev`

## Cosmovisor proof
`make tsh-upgrade-cv` → `tests/tsh/upgrade/e.sh`

Genesis binary = current `terp-mainnet`; `upgrades/v6` = this tree. Cosmovisor must **stay running** across halt and apply v6.

## How to run
```sh
SKIP_INSTALL=1 make tsh-upgrade-cv
# companion: tests/tsh/upgrade/b.sh (manual restart path)
```