### PR TITLE
fix(release): Cosmovisor S3 URLs are v6.1.0/v6.2.0 not -dev

### DIFF
--- a/networks/chain-registry/terpnetwork/versions.json
+++ b/networks/chain-registry/terpnetwork/versions.json
@@ -230,9 +230,9 @@
       "name": "v6.1",
       "proposal": null,
       "height": null,
-      "recommended_version": "v6.1.0-dev",
+      "recommended_version": "v6.1.0",
       "compatible_versions": [
-        "v6.1.0-dev"
+        "v6.1.0"
       ],
       "consensus": {
         "type": "cometbft",
@@ -252,7 +252,41 @@
         "path": "$HOME/.terpd/data/wasm"
       },
       "next_version_name": "v6.2",
-      "binaries": {}
+      "binaries": {
+        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-amd64.tar.gz",
+        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-arm64.tar.gz"
+      }
+    },
+    {
+      "name": "v6.2",
+      "proposal": null,
+      "height": null,
+      "recommended_version": "v6.2.0",
+      "compatible_versions": [
+        "v6.2.0"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.40.0"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.55.0"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v11.2.0"
+      },
+      "cosmwasm": {
+        "version": "0.70.3-zk",
+        "enabled": true,
+        "path": "$HOME/.terpd/data/wasm"
+      },
+      "next_version_name": null,
+      "binaries": {
+        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-amd64.tar.gz",
+        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-arm64.tar.gz"
+      }
     }
   ]
 }

--- a/networks/upgrades/v6.1/ARTIFACT_LOCK
+++ b/networks/upgrades/v6.1/ARTIFACT_LOCK
@@ -1,12 +1,13 @@
 plan: v6.1
-binary_tag: v6.1.0-dev
-binary_commit: 240e1f7c3420f09153c9bc8733ec15db1a9799d0
-dirty: v6.0.0-27-g240e1f7-dirty
-s3_binaries_intended: https://s3.terp.network/releases/terp-core/v6.1.0-dev/
-published: false
-note: checksums are of local tarballs; do not upload until asked.
+binary_tag: v6.1.0
+binary_commit: 2d3b2587c7da2feb4601a9dd93c0899122dbfd06
+pack_branch: release/v6.1.0
+dirty: v6.1.0-10-gc6854f6-dirty
+s3_binaries_intended: https://s3.terp.network/releases/terp-core/v6.1.0/
+published: true
+note: ELF identity is git tag v6.1.0. Pack files belong on release/v6.1.0 and must not move the tag.
 
-663c15949182cac66459ad5f45d5d0a612a78d829d9cd1e77ecfee62bd21db87  terpd-6.1.0-dev-linux-amd64.tar.gz
-1b027568836bb6fa172b8d3ebf43d24db3c1485572507c321c307b066b1988d5  terpd-6.1.0-dev-linux-arm64.tar.gz
-c11af8d8bdf1a8fe51a9ab8241c59d30b6c110fba96e8c8f8d2b5b2c09418160  terpd-linux-amd64
-c9f7ef4e096a2ab48f2fce2b6c8c5783934feef28f666b56ee60a52e06c3a45f  terpd-linux-arm64
+c0defc03627d83a9524dd1febc1cb5c87c215dbf70e0c008139168d022a5f8f8  terpd-6.1.0-linux-amd64.tar.gz
+c41ab84a572ea4e6a7994433ef3e7861637286f79b25cc3bc3ce04329bc0c371  terpd-6.1.0-linux-arm64.tar.gz
+478ad2c0571ebb2ce5271574c8ca007e98dd509b364da128972b7bd865ee7486  terpd-linux-amd64
+ccfc2c1511a9507ded6a969b22b5a340c40e8ae0c60ee8828c61946179741c82  terpd-linux-arm64

--- a/networks/upgrades/v6.1/binaries.json
+++ b/networks/upgrades/v6.1/binaries.json
@@ -1,6 +1,6 @@
 {
   "binaries": {
-    "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.1.0-dev/terpd-6.1.0-dev-linux-amd64.tar.gz?checksum=sha256:663c15949182cac66459ad5f45d5d0a612a78d829d9cd1e77ecfee62bd21db87",
-    "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.1.0-dev/terpd-6.1.0-dev-linux-arm64.tar.gz?checksum=sha256:1b027568836bb6fa172b8d3ebf43d24db3c1485572507c321c307b066b1988d5"
+    "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-amd64.tar.gz?checksum=sha256:ab7e4bb907914b5cb256b69f7ff7f503393800d108b0d01791572c281de5dcb0",
+    "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-arm64.tar.gz?checksum=sha256:0b7351db40d9d5180a4aec4ab00a75f96a3096b3f2bede55d7bafda3bccfeb8c"
   }
 }

--- a/networks/upgrades/v6.1/cosmovisor.json
+++ b/networks/upgrades/v6.1/cosmovisor.json
@@ -1,6 +1,6 @@
 {
   "binaries": {
-    "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.1.0-dev/terpd-6.1.0-dev-linux-amd64.tar.gz?checksum=sha256:663c15949182cac66459ad5f45d5d0a612a78d829d9cd1e77ecfee62bd21db87",
-    "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.1.0-dev/terpd-6.1.0-dev-linux-arm64.tar.gz?checksum=sha256:1b027568836bb6fa172b8d3ebf43d24db3c1485572507c321c307b066b1988d5"
+    "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-amd64.tar.gz?checksum=sha256:c0defc03627d83a9524dd1febc1cb5c87c215dbf70e0c008139168d022a5f8f8",
+    "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-arm64.tar.gz?checksum=sha256:c41ab84a572ea4e6a7994433ef3e7861637286f79b25cc3bc3ce04329bc0c371"
   }
 }

--- a/networks/upgrades/v6.1/draft_proposal.json
+++ b/networks/upgrades/v6.1/draft_proposal.json
@@ -7,14 +7,14 @@
         "name": "v6.1",
         "time": "0001-01-01T00:00:00Z",
         "height": "0",
-        "info": "{\"binaries\":{\"linux/amd64\":\"https://s3.terp.network/releases/terp-core/v6.1.0-dev/terpd-6.1.0-dev-linux-amd64.tar.gz?checksum=sha256:663c15949182cac66459ad5f45d5d0a612a78d829d9cd1e77ecfee62bd21db87\",\"linux/arm64\":\"https://s3.terp.network/releases/terp-core/v6.1.0-dev/terpd-6.1.0-dev-linux-arm64.tar.gz?checksum=sha256:1b027568836bb6fa172b8d3ebf43d24db3c1485572507c321c307b066b1988d5\"}}",
+        "info": "{\"binaries\":{\"linux/amd64\":\"https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-amd64.tar.gz?checksum=sha256:c0defc03627d83a9524dd1febc1cb5c87c215dbf70e0c008139168d022a5f8f8\",\"linux/arm64\":\"https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-arm64.tar.gz?checksum=sha256:c41ab84a572ea4e6a7994433ef3e7861637286f79b25cc3bc3ce04329bc0c371\"}}",
         "upgraded_client_state": null
       }
     }
   ],
   "metadata": "",
   "deposit": "50000000uterp",
-  "title": "Software Upgrade v6.1 (v6.1.0-dev)",
-  "summary": "Plan v6.1. HashMerchant consensus version 2 with bounded sudo gas for wasm callbacks (contract_gas_limit default 100663296). CircuitUploadAccess Nobody; copy migratable IAVL stores into b3-* (IBC stays SHA-256). Pin wasm via gov MsgPinCodes; LRU memory_cache_size stays 100 MiB per VM. Halt height TBD. Pre-place Cosmovisor binary at cosmovisor/upgrades/v6.1/bin/terpd. S3 objects are not public until upload is asked; DAEMON_ALLOW_DOWNLOAD_BINARIES=false until then.",
+  "title": "Software Upgrade v6.1 (v6.1.0)",
+  "summary": "Plan v6.1. HashMerchant consensus version 2 with bounded sudo gas for wasm callbacks (contract_gas_limit default 100663296). CircuitUploadAccess Nobody; copy migratable IAVL stores into b3-* (IBC stays SHA-256). Pin wasm via gov MsgPinCodes; LRU memory_cache_size stays 100 MiB per VM. Halt height TBD. Pre-place Cosmovisor binary at cosmovisor/upgrades/v6.1/bin/terpd. Cosmovisor auto-download URLs are the published linux tarballs under releases/terp-core/v6.1.0/.",
   "expedited": true
 }

--- a/networks/upgrades/v6.2/ARTIFACT_LOCK
+++ b/networks/upgrades/v6.2/ARTIFACT_LOCK
@@ -1,12 +1,13 @@
 plan: v6.2
-binary_tag: v6.2.0-dev
-binary_commit: ca3f7ac8ed0c6027cfd6683f29db94b9b53ad218
-dirty: v6.0.0-35-gca3f7ac-dirty
-s3_binaries_intended: https://s3.terp.network/releases/terp-core/v6.2.0-dev/
-published: false
-note: checksums are of local tarballs; do not upload until asked.
+binary_tag: v6.2.0
+binary_commit: 0c24074ea7a97c04119d890b224a56563325135d
+pack_branch: release/v6.2.0
+dirty: v6.2.0-12-g7233a37-dirty
+s3_binaries_intended: https://s3.terp.network/releases/terp-core/v6.2.0/
+published: true
+note: ELF identity is git tag v6.2.0. Pack files belong on release/v6.2.0 and must not move the tag.
 
-3ec11bc7ec2886c4631f9573e790ada32e813f1d82017360255576614146f0eb  terpd-6.2.0-dev-linux-amd64.tar.gz
-7fdfc0468387ac557f8acdd6d7388dcb76c1c6671b637f104056995e1862ba63  terpd-6.2.0-dev-linux-arm64.tar.gz
-2cc658ae71fc0efd78eb31ae75e025694b80627b3ad445ce2bf8232099639388  terpd-linux-amd64
-7cc729795fbcb045c938030f4c7a3ea6ed96226cab8b175fa8cb12710a74e738  terpd-linux-arm64
+38c15e1f54bc8234d07883c05e665ded68fdc0434c1c9db08de796d15ef491f6  terpd-6.2.0-linux-amd64.tar.gz
+148eedb6e8f1dd97e2436bc1b36dfebdbc915d23c14e6bad483924b0a4052c3d  terpd-6.2.0-linux-arm64.tar.gz
+d7f8c1b4500db247f72444fa2d13d7b48c07f521126e9a4704a8b1952647420e  terpd-linux-amd64
+36e5575702ce357634584afea728ce617f0aee972cb1e70318c15dc2532fd293  terpd-linux-arm64

--- a/networks/upgrades/v6.2/binaries.json
+++ b/networks/upgrades/v6.2/binaries.json
@@ -1,6 +1,6 @@
 {
   "binaries": {
-    "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.2.0-dev/terpd-6.2.0-dev-linux-amd64.tar.gz?checksum=sha256:3ec11bc7ec2886c4631f9573e790ada32e813f1d82017360255576614146f0eb",
-    "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.2.0-dev/terpd-6.2.0-dev-linux-arm64.tar.gz?checksum=sha256:7fdfc0468387ac557f8acdd6d7388dcb76c1c6671b637f104056995e1862ba63"
+    "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-amd64.tar.gz?checksum=sha256:bdd6583528deac0d579f8f8e65045b438536135995c96a4e73a4456c6e55426a",
+    "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-arm64.tar.gz?checksum=sha256:f804d18de9ba179a725163e4b1682e721eb29e14adb643ad9691cda64a497921"
   }
 }

--- a/networks/upgrades/v6.2/cosmovisor.json
+++ b/networks/upgrades/v6.2/cosmovisor.json
@@ -1,6 +1,6 @@
 {
   "binaries": {
-    "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.2.0-dev/terpd-6.2.0-dev-linux-amd64.tar.gz?checksum=sha256:3ec11bc7ec2886c4631f9573e790ada32e813f1d82017360255576614146f0eb",
-    "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.2.0-dev/terpd-6.2.0-dev-linux-arm64.tar.gz?checksum=sha256:7fdfc0468387ac557f8acdd6d7388dcb76c1c6671b637f104056995e1862ba63"
+    "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-amd64.tar.gz?checksum=sha256:38c15e1f54bc8234d07883c05e665ded68fdc0434c1c9db08de796d15ef491f6",
+    "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-arm64.tar.gz?checksum=sha256:148eedb6e8f1dd97e2436bc1b36dfebdbc915d23c14e6bad483924b0a4052c3d"
   }
 }

--- a/networks/upgrades/v6.2/draft_proposal.json
+++ b/networks/upgrades/v6.2/draft_proposal.json
@@ -7,14 +7,14 @@
         "name": "v6.2",
         "time": "0001-01-01T00:00:00Z",
         "height": "0",
-        "info": "{\"binaries\":{\"linux/amd64\":\"https://s3.terp.network/releases/terp-core/v6.2.0-dev/terpd-6.2.0-dev-linux-amd64.tar.gz?checksum=sha256:3ec11bc7ec2886c4631f9573e790ada32e813f1d82017360255576614146f0eb\",\"linux/arm64\":\"https://s3.terp.network/releases/terp-core/v6.2.0-dev/terpd-6.2.0-dev-linux-arm64.tar.gz?checksum=sha256:7fdfc0468387ac557f8acdd6d7388dcb76c1c6671b637f104056995e1862ba63\"}}",
+        "info": "{\"binaries\":{\"linux/amd64\":\"https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-amd64.tar.gz?checksum=sha256:38c15e1f54bc8234d07883c05e665ded68fdc0434c1c9db08de796d15ef491f6\",\"linux/arm64\":\"https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-arm64.tar.gz?checksum=sha256:148eedb6e8f1dd97e2436bc1b36dfebdbc915d23c14e6bad483924b0a4052c3d\"}}",
         "upgraded_client_state": null
       }
     }
   ],
   "metadata": "",
   "deposit": "50000000uterp",
-  "title": "Software Upgrade v6.2 (v6.2.0-dev)",
-  "summary": "Plan v6.2 after v6.1. Keepers stay bank/staking/acc; unmounted b3-* dest trees drop from CommitInfo. IBC stays SHA-256. Bounded sudo gas already in the v6.1 binary (HashMerchant consensus 2, contract_gas_limit 100663296). Halt height TBD. Pre-place Cosmovisor at cosmovisor/upgrades/v6.2/bin/terpd. S3 objects are not public until upload is asked.",
+  "title": "Software Upgrade v6.2 (v6.2.0)",
+  "summary": "Plan v6.2 after v6.1. Keepers stay bank/staking/acc; unmounted b3-* dest trees drop from CommitInfo. IBC stays SHA-256. Bounded sudo gas already in the v6.1 binary (HashMerchant consensus 2, contract_gas_limit 100663296). Halt height TBD. Pre-place Cosmovisor at cosmovisor/upgrades/v6.2/bin/terpd. Cosmovisor auto-download URLs are the published linux tarballs under releases/terp-core/v6.2.0/.",
   "expedited": true
 }

--- a/networks/upgrades/v6.2/dual_proposal.json
+++ b/networks/upgrades/v6.2/dual_proposal.json
@@ -7,7 +7,7 @@
         "name": "v6.1",
         "time": "0001-01-01T00:00:00Z",
         "height": "0",
-        "info": "{\"binaries\":{\"linux/amd64\":\"https://s3.terp.network/releases/terp-core/v6.1.0-dev/terpd-6.1.0-dev-linux-amd64.tar.gz?checksum=sha256:663c15949182cac66459ad5f45d5d0a612a78d829d9cd1e77ecfee62bd21db87\",\"linux/arm64\":\"https://s3.terp.network/releases/terp-core/v6.1.0-dev/terpd-6.1.0-dev-linux-arm64.tar.gz?checksum=sha256:1b027568836bb6fa172b8d3ebf43d24db3c1485572507c321c307b066b1988d5\"}}",
+        "info": "{\"binaries\":{\"linux/amd64\":\"https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-amd64.tar.gz?checksum=sha256:c0defc03627d83a9524dd1febc1cb5c87c215dbf70e0c008139168d022a5f8f8\",\"linux/arm64\":\"https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-arm64.tar.gz?checksum=sha256:c41ab84a572ea4e6a7994433ef3e7861637286f79b25cc3bc3ce04329bc0c371\"}}",
         "upgraded_client_state": null
       }
     },
@@ -18,7 +18,7 @@
         "name": "v6.2",
         "time": "0001-01-01T00:00:00Z",
         "height": "0",
-        "info": "{\"binaries\":{\"linux/amd64\":\"https://s3.terp.network/releases/terp-core/v6.2.0-dev/terpd-6.2.0-dev-linux-amd64.tar.gz?checksum=sha256:3ec11bc7ec2886c4631f9573e790ada32e813f1d82017360255576614146f0eb\",\"linux/arm64\":\"https://s3.terp.network/releases/terp-core/v6.2.0-dev/terpd-6.2.0-dev-linux-arm64.tar.gz?checksum=sha256:7fdfc0468387ac557f8acdd6d7388dcb76c1c6671b637f104056995e1862ba63\"}}",
+        "info": "{\"binaries\":{\"linux/amd64\":\"https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-amd64.tar.gz?checksum=sha256:38c15e1f54bc8234d07883c05e665ded68fdc0434c1c9db08de796d15ef491f6\",\"linux/arm64\":\"https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-arm64.tar.gz?checksum=sha256:148eedb6e8f1dd97e2436bc1b36dfebdbc915d23c14e6bad483924b0a4052c3d\"}}",
         "upgraded_client_state": null
       }
     }
@@ -26,6 +26,6 @@
   "metadata": "",
   "deposit": "50000000uterp",
   "title": "v6.1 then v6.2 (Upgrade A then B)",
-  "summary": "Two MsgSoftwareUpgrade in one proposal (heights TBD). x/upgrade keeps one plan (last wins). The v6.1 handler re-arms v6.2 at BlockHeight()+2. Cosmovisor pre-places upgrades/v6.1 and upgrades/v6.2. Do not broadcast until heights are filled. S3 URLs are intended locations until upload is asked.",
+  "summary": "Two MsgSoftwareUpgrade in one proposal (heights TBD). x/upgrade keeps one plan (last wins). The v6.1 handler re-arms v6.2 at BlockHeight()+2. Cosmovisor pre-places upgrades/v6.1 and upgrades/v6.2. x/upgrade last-wins: do not broadcast this dual file. Submit only plan v6.1. S3 URLs match published v6.1.0/v6.2.0 tarballs.",
   "expedited": true
 }

--- a/scripts/release/publish_s3_upgrade.sh
+++ b/scripts/release/publish_s3_upgrade.sh
@@ -58,8 +58,10 @@ if [ "$DRY_RUN" != "1" ]; then
 fi
 
 run_mc cp "$SRC/cosmovisor.json" "${DEST}/cosmovisor.json"
-if [ -f "$SRC/draft_proposal.json" ]; then
-  run_mc cp "$SRC/draft_proposal.json" "${DEST}/draft_proposal.json"
-fi
+for f in binaries.json draft_proposal.json ARTIFACT_LOCK guide.md sha256sum.txt; do
+  if [ -f "$SRC/$f" ]; then
+    run_mc cp "$SRC/$f" "${DEST}/$f"
+  fi
+done
 
 echo "  public: https://s3.terp.network/upgrades/${PLAN}/cosmovisor.json"


### PR DESCRIPTION
Main Cosmovisor JSON and draft_proposal plan.info still pointed at \`v6.1.0-dev\` / \`v6.2.0-dev\` tarballs that 404. The recut linux tarballs already live at \`releases/terp-core/v6.1.0/\` and \`v6.2.0/\`. This copies ARTIFACT_LOCK + cosmovisor.json from the pack branches, fills chain-registry binaries, and publishes \`upgrades/v6.1\` + \`upgrades/v6.2\` after merge.

Do not retag. ELF identity remains tags v6.1.0 / v6.2.0.