### PR TITLE
Docs: chain-registry v6.0.1 through v6.2.0

### DIFF
--- a/networks/chain-registry/README.md
+++ b/networks/chain-registry/README.md
@@ -13,14 +13,22 @@ under `docs/`, or under `networks/upgrades/*/`.
 | Kind | Host |
 |------|------|
 | Source, checksums, binaries, manifests | `https://s3.terp.network/releases/terp-core/<tag>/` |
-| Container images | `containers.terp.network/terp-core:<tag>` |
+| Container images | `registry.terp.network/terp-core:<tag>` |
+
+Sequence (morocco-1):
+
+| step | version | halt | artifacts |
+|------|---------|------|-----------|
+| now (rolling patch) | **v6.0.1** | none | `releases/terp-core/v6.0.1/` + `registry.terp.network/terp-core:v6.0.1` (linux amd64) |
+| gov plan `v6.1` (proposal 59) | **v6.1.0** | **23191300** | `releases/terp-core/v6.1.0/` |
+| handler arms `v6.2` at apply+2 | **v6.2.0** | **23191302** | `releases/terp-core/v6.2.0/` |
+
+`chain.json` `recommended_version` is **v6.0.1** until the v6.1 halt. Do not run v6.1.0 / v6.2.0 before height 23191300.
 
 Example:
 
 ```
-https://s3.terp.network/releases/terp-core/v6.0.0/manifest.json
-https://s3.terp.network/releases/terp-core/v6.0.0/terpd-6.0.0-linux-amd64.tar.gz
-containers.terp.network/terp-core:v6.0.0
+https://s3.terp.network/releases/terp-core/v6.0.1/sha256sum.txt
+https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-amd64.tar.gz
+registry.terp.network/terp-core:v6.0.1
 ```
-
-`recommended_version` stays on **v5.2.0** until v6 is tagged and the halt succeeds.

--- a/networks/chain-registry/README.md
+++ b/networks/chain-registry/README.md
@@ -2,7 +2,7 @@
 
 This tree is the **only** file we tune. Path: `networks/chain-registry/terpnetwork/{chain,versions}.json`.
 
-GitHub cannot symlink `cosmos/chain-registry` at our terp-core files. After editing SoT, copy into a chain-registry clone and open a PR:
+A GitHub PR cannot contain a symlink into terp-core (the target does not exist in `cosmos/chain-registry`). Edit here, then copy into a chain-registry clone before the PR:
 
 ```
 make sync-chain-registry

--- a/networks/chain-registry/README.md
+++ b/networks/chain-registry/README.md
@@ -1,12 +1,15 @@
 # Chain registry (SoT)
 
-This tree is the **only** in-repo copy of the Terp chain-registry draft.
+This tree is the **only** file we tune. Path: `networks/chain-registry/terpnetwork/{chain,versions}.json`.
 
-Path: `networks/chain-registry/terpnetwork/`
+GitHub cannot symlink `cosmos/chain-registry` at our terp-core files. After editing SoT, copy into a chain-registry clone and open a PR:
 
-Upstream `cosmos/chain-registry/terpnetwork` is updated by PR **after** a
-release is public on our hosts. Do not add a second copy at repo root,
-under `docs/`, or under `networks/upgrades/*/`.
+```
+make sync-chain-registry
+# or: DEST=/path/to/chain-registry make sync-chain-registry
+```
+
+Do not keep a second edited copy under `docs/` or `networks/upgrades/*/`. The `crates/chain-registry` checkout is gitignored (`crates/*`); it is only the publish clone.
 
 ## Where operators fetch artifacts
 

--- a/networks/chain-registry/terpnetwork/chain.json
+++ b/networks/chain-registry/terpnetwork/chain.json
@@ -9,7 +9,7 @@
   "bech32_prefix": "terp",
   "slip44": 118,
   "daemon_name": "terp",
-  "node_home": "$HOME/.terp",
+  "node_home": "$HOME/.terpd",
   "codebase": {
     "git_repo": "https://github.com/terpnetwork/terp-core.git",
     "genesis": {
@@ -29,7 +29,7 @@
     },
     "ibc": {
       "type": "go",
-      "version": "v11.1.0"
+      "version": "v11.2.0"
     },
     "cosmwasm": {
       "version": "0.70.3",
@@ -74,7 +74,7 @@
       {
         "id": "8542cd7e6bf9d260fef543bc49e59be5a3fa9074",
         "address": "seed.publicnode.com:26656",
-        "provider": "Allnodes \u26a1\ufe0f Nodes & Staking"
+        "provider": "Allnodes ⚡️ Nodes & Staking"
       }
     ],
     "persistent_peers": [
@@ -115,7 +115,7 @@
       },
       {
         "address": "https://terp.api.m.stavr.tech",
-        "provider": "\ud83d\udd25STAVR\ud83d\udd25"
+        "provider": "🔥STAVR🔥"
       }
     ],
     "grpc": [
@@ -151,7 +151,7 @@
       "account_page": "https://explorer.nodestake.top/terp/account/{$accountAddress}"
     },
     {
-      "kind": "\ud83d\udd25STAVR\ud83d\udd25",
+      "kind": "🔥STAVR🔥",
       "url": "https://explorer.stavr.tech/Terp-Mainnet",
       "tx_page": "https://explorer.stavr.tech/Terp-Mainnet/tx/${txHash}",
       "account_page": "https://explorer.stavr.tech/Terp-Mainnet/account/{$accountAddress}"

--- a/networks/chain-registry/terpnetwork/chain.json
+++ b/networks/chain-registry/terpnetwork/chain.json
@@ -15,9 +15,9 @@
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/terpnetwork/networks/main/mainnet/morocco-1/genesis.json"
     },
-    "recommended_version": "v6.0.0",
+    "recommended_version": "v6.0.1",
     "compatible_versions": [
-      "v6.0.0"
+      "v6.0.1"
     ],
     "consensus": {
       "type": "cometbft",
@@ -37,9 +37,8 @@
       "path": "$HOME/.terpd/data/wasm"
     },
     "binaries": {
-      "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.0.0/terpd-6.0.0-linux-amd64.tar.gz",
-      "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.0.0/terpd-6.0.0-linux-arm64.tar.gz",
-      "darwin/arm64": "https://s3.terp.network/releases/terp-core/v6.0.0/terpd-6.0.0-darwin-arm64.tar.gz"
+      "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-amd64.tar.gz?checksum=sha256:e4dd72f5a6cba3af602b49e51ee79229432f5de02dc23e586c5c6b7768dc285c",
+      "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-arm64.tar.gz?checksum=sha256:0b8d21b0bbe3cb593fb77c5cdd413d712aaf9465981180e2ca1f074f81c5cbc8"
     }
   },
   "fees": {

--- a/networks/chain-registry/terpnetwork/versions.json
+++ b/networks/chain-registry/terpnetwork/versions.json
@@ -164,7 +164,6 @@
     },
     {
       "name": "v5.2.0",
-      "proposal": null,
       "height": 21725359,
       "recommended_version": "v5.2.0",
       "compatible_versions": [
@@ -196,7 +195,6 @@
     },
     {
       "name": "v6",
-      "proposal": null,
       "height": 22611000,
       "recommended_version": "v6.0.0",
       "compatible_versions": [
@@ -224,12 +222,12 @@
         "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.0.0/terpd-6.0.0-linux-amd64.tar.gz",
         "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.0.0/terpd-6.0.0-linux-arm64.tar.gz",
         "darwin/arm64": "https://s3.terp.network/releases/terp-core/v6.0.0/terpd-6.0.0-darwin-arm64.tar.gz"
-      }
+      },
+      "tag": "v6.0.0",
+      "previous_version_name": "v5.2.0"
     },
     {
       "name": "v6.0.1",
-      "proposal": null,
-      "height": null,
       "recommended_version": "v6.0.1",
       "compatible_versions": [
         "v6.0.1"
@@ -255,7 +253,9 @@
       "binaries": {
         "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-amd64.tar.gz?checksum=sha256:e4dd72f5a6cba3af602b49e51ee79229432f5de02dc23e586c5c6b7768dc285c",
         "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-arm64.tar.gz?checksum=sha256:0b8d21b0bbe3cb593fb77c5cdd413d712aaf9465981180e2ca1f074f81c5cbc8"
-      }
+      },
+      "tag": "v6.0.1",
+      "previous_version_name": "v6"
     },
     {
       "name": "v6.1",
@@ -278,7 +278,7 @@
         "version": "v11.2.0"
       },
       "cosmwasm": {
-        "version": "0.70.3-zk",
+        "version": "0.70.3",
         "enabled": true,
         "path": "$HOME/.terpd/data/wasm"
       },
@@ -286,11 +286,12 @@
       "binaries": {
         "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-amd64.tar.gz?checksum=sha256:18a073f5d189f823987bd73d1ee6d410f9f48bbdcc92258fcbf8ae800780ebd2",
         "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-arm64.tar.gz?checksum=sha256:4249119ebdbf75535c6852226fb7dee477373d65d2b721708bbb5265e8fdd8b4"
-      }
+      },
+      "tag": "v6.1.0",
+      "previous_version_name": "v6.0.1"
     },
     {
       "name": "v6.2",
-      "proposal": null,
       "height": 23191302,
       "recommended_version": "v6.2.0",
       "compatible_versions": [
@@ -309,15 +310,16 @@
         "version": "v11.2.0"
       },
       "cosmwasm": {
-        "version": "0.70.3-zk",
+        "version": "0.70.3",
         "enabled": true,
         "path": "$HOME/.terpd/data/wasm"
       },
-      "next_version_name": null,
       "binaries": {
         "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-amd64.tar.gz?checksum=sha256:38c15e1f54bc8234d07883c05e665ded68fdc0434c1c9db08de796d15ef491f6",
         "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-arm64.tar.gz?checksum=sha256:148eedb6e8f1dd97e2436bc1b36dfebdbc915d23c14e6bad483924b0a4052c3d"
-      }
+      },
+      "tag": "v6.2.0",
+      "previous_version_name": "v6.1"
     }
   ]
 }

--- a/networks/chain-registry/terpnetwork/versions.json
+++ b/networks/chain-registry/terpnetwork/versions.json
@@ -219,7 +219,7 @@
         "enabled": true,
         "path": "$HOME/.terpd/data/wasm"
       },
-      "next_version_name": "v6.1",
+      "next_version_name": "v6.0.1",
       "binaries": {
         "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.0.0/terpd-6.0.0-linux-amd64.tar.gz",
         "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.0.0/terpd-6.0.0-linux-arm64.tar.gz",
@@ -227,9 +227,40 @@
       }
     },
     {
-      "name": "v6.1",
+      "name": "v6.0.1",
       "proposal": null,
       "height": null,
+      "recommended_version": "v6.0.1",
+      "compatible_versions": [
+        "v6.0.1"
+      ],
+      "consensus": {
+        "type": "cometbft",
+        "version": "0.39.3"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "0.54.3"
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v11.1.0"
+      },
+      "cosmwasm": {
+        "version": "0.70.3",
+        "enabled": true,
+        "path": "$HOME/.terpd/data/wasm"
+      },
+      "next_version_name": "v6.1",
+      "binaries": {
+        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-amd64.tar.gz?checksum=sha256:e4dd72f5a6cba3af602b49e51ee79229432f5de02dc23e586c5c6b7768dc285c",
+        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.0.1/terpd-6.0.1-linux-arm64.tar.gz?checksum=sha256:0b8d21b0bbe3cb593fb77c5cdd413d712aaf9465981180e2ca1f074f81c5cbc8"
+      }
+    },
+    {
+      "name": "v6.1",
+      "proposal": 59,
+      "height": 23191300,
       "recommended_version": "v6.1.0",
       "compatible_versions": [
         "v6.1.0"
@@ -253,14 +284,14 @@
       },
       "next_version_name": "v6.2",
       "binaries": {
-        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-amd64.tar.gz",
-        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-arm64.tar.gz"
+        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-amd64.tar.gz?checksum=sha256:18a073f5d189f823987bd73d1ee6d410f9f48bbdcc92258fcbf8ae800780ebd2",
+        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.1.0/terpd-6.1.0-linux-arm64.tar.gz?checksum=sha256:4249119ebdbf75535c6852226fb7dee477373d65d2b721708bbb5265e8fdd8b4"
       }
     },
     {
       "name": "v6.2",
       "proposal": null,
-      "height": null,
+      "height": 23191302,
       "recommended_version": "v6.2.0",
       "compatible_versions": [
         "v6.2.0"
@@ -284,8 +315,8 @@
       },
       "next_version_name": null,
       "binaries": {
-        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-amd64.tar.gz",
-        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-arm64.tar.gz"
+        "linux/amd64": "https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-amd64.tar.gz?checksum=sha256:38c15e1f54bc8234d07883c05e665ded68fdc0434c1c9db08de796d15ef491f6",
+        "linux/arm64": "https://s3.terp.network/releases/terp-core/v6.2.0/terpd-6.2.0-linux-arm64.tar.gz?checksum=sha256:148eedb6e8f1dd97e2436bc1b36dfebdbc915d23c14e6bad483924b0a4052c3d"
       }
     }
   ]

--- a/networks/chain-registry/terpnetwork/versions.json
+++ b/networks/chain-registry/terpnetwork/versions.json
@@ -210,7 +210,7 @@
       },
       "ibc": {
         "type": "go",
-        "version": "v11.1.0"
+        "version": "v11.2.0"
       },
       "cosmwasm": {
         "version": "0.70.3",
@@ -242,7 +242,7 @@
       },
       "ibc": {
         "type": "go",
-        "version": "v11.1.0"
+        "version": "v11.2.0"
       },
       "cosmwasm": {
         "version": "0.70.3",

--- a/scripts/makefiles/release.mk
+++ b/scripts/makefiles/release.mk
@@ -53,6 +53,7 @@ release-help:
 	@echo "  verify-upgrade-pack     Fail-closed: binaries.json == cosmovisor.json == proposal == lock"
 	@echo "  test-upgrade-pack       Drift regression (corrupt binaries.json must fail verify)"
 	@echo "  recurate-upgrade-binaries  Rebuild tagged ELF and compare ARTIFACT_LOCK"
+	@echo "  sync-chain-registry      Copy networks/chain-registry/terpnetwork into a cosmos/chain-registry clone"
 	@echo "  release-dev              bundle + s3 for RELEASE_TAG (default $(RELEASE_TAG))"
 	@echo "  docker-publish-dev       (docker.mk) ZK image tagged RELEASE_TAG"
 	@echo "  docker-push-dev          (docker.mk) push IMAGE_REPO:RELEASE_TAG"

--- a/scripts/makefiles/release.mk
+++ b/scripts/makefiles/release.mk
@@ -9,7 +9,8 @@ WASMVM_VERSION=$(go list -m github.com/CosmWasm/wasmvm/v3 | awk '{print $2}')
 	create-binaries create-checksums release-prep create-binaries-json \
 	create-upgrade-guide release-proposal upgrade-proposal \
 	release-bundle release-s3 release-dev release-control \
-	sync-upgrade-pack verify-upgrade-pack test-upgrade-pack recurate-upgrade-binaries
+	sync-upgrade-pack verify-upgrade-pack test-upgrade-pack recurate-upgrade-binaries \
+	sync-chain-registry
 
 # Shared with docker.mk for version-aligned testnet/ZK releases
 RELEASE_TAG ?= v6.0.0-dev
@@ -255,6 +256,13 @@ upgrade-proposal:
 		--proposal "$(or $(PROPOSAL),$(CURDIR)/networks/upgrades/v6.1/draft_proposal.json)" \
 		--env-file "$(CURDIR)/scripts/release/.env" \
 		$(if $(filter 1,$(BROADCAST)),--broadcast,)
+
+###############################################################################
+# cosmos/chain-registry publish (SoT is networks/chain-registry/terpnetwork)
+###############################################################################
+
+sync-chain-registry:
+	@DEST=$(or $(DEST),$(CURDIR)/crates/chain-registry) bash scripts/release/sync_chain_registry.sh
 
 ###############################################################################
 # Deterministic source bundle + MinIO/S3 publish (testnet ZK lineage)

--- a/scripts/release/sync_chain_registry.sh
+++ b/scripts/release/sync_chain_registry.sh
@@ -32,7 +32,14 @@ for name in ("chain.json", "versions.json"):
             return [drop_null(x) for x in o]
         return o
     out = dest / name
-    out.write_text(json.dumps(drop_null(data), indent=2) + "\n")
+    # GitHub cannot store a symlink into terp-core. If a local clone
+    # used a symlink for one-file editing, replace it with real JSON.
+    if out.is_symlink() or out.exists():
+        out.unlink()
+    out.write_text(
+        json.dumps(drop_null(data), indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
     print(f"copied {name} -> {out}")
 PY
 echo "SoT: $SRC"

--- a/scripts/release/sync_chain_registry.sh
+++ b/scripts/release/sync_chain_registry.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Copy terp-core chain-registry SoT into a cosmos/chain-registry checkout.
+#
+# GitHub cannot follow a symlink from cosmos/chain-registry into terp-core.
+# Tune files only under networks/chain-registry/terpnetwork/, then run this
+# before opening a chain-registry PR (materialized JSON, not a symlink).
+#
+#   ./scripts/release/sync_chain_registry.sh
+#   DEST=/path/to/chain-registry ./scripts/release/sync_chain_registry.sh
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SRC="$ROOT/networks/chain-registry/terpnetwork"
+DEST="${DEST:-$ROOT/crates/chain-registry}"
+if [ ! -f "$SRC/chain.json" ] || [ ! -f "$SRC/versions.json" ]; then
+  echo "ERROR: missing SoT at $SRC" >&2
+  exit 1
+fi
+if [ ! -d "$DEST/terpnetwork" ]; then
+  echo "ERROR: $DEST/terpnetwork not found (clone cosmos/chain-registry or the permissionlessweb fork)" >&2
+  exit 1
+fi
+python3 - "$SRC" "$DEST/terpnetwork" <<'PY'
+import json, sys
+from pathlib import Path
+src, dest = Path(sys.argv[1]), Path(sys.argv[2])
+for name in ("chain.json", "versions.json"):
+    data = json.loads((src / name).read_text())
+    def drop_null(o):
+        if isinstance(o, dict):
+            return {k: drop_null(v) for k, v in o.items() if v is not None}
+        if isinstance(o, list):
+            return [drop_null(x) for x in o]
+        return o
+    out = dest / name
+    out.write_text(json.dumps(drop_null(data), indent=2) + "\n")
+    print(f"copied {name} -> {out}")
+PY
+echo "SoT: $SRC"
+echo "Dest: $DEST/terpnetwork"
+echo "Open a PR from that clone onto cosmos/chain-registry. Do not commit a symlink."


### PR DESCRIPTION
## Summary
- Record the shipped v6.0.1 → v6.1.0 → v6.2.0 registry line, schema, and node home.
- No hasher or v6.3 binary changes.

## Test plan
- [ ] `chain.json` and `versions.json` still match the published v6.2 artifacts.